### PR TITLE
chore: bump aws credentials action to v6.0.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
         env | sort
         pnpm run build
     - name: Assume role using OIDC
-      uses: aws-actions/configure-aws-credentials@v5.1.1
+      uses: aws-actions/configure-aws-credentials@v6.0.0
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.aws_role }}


### PR DESCRIPTION
## Summary
- bump `aws-actions/configure-aws-credentials` from `v5.1.1` to `v6.0.0`

## Validation
- `act --container-architecture linux/amd64 --container-daemon-socket - --container-options "--memory 4g" workflow_dispatch -W .github/workflows/build.yml -j build -s GITHUB_TOKEN="$TOKEN"`
- result: success
