### PR TITLE
chore: bump cloudfront invalidate action to v2.4.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
         env | sort
         pnpm run build
     - name: Assume role using OIDC
-      uses: aws-actions/configure-aws-credentials@v5.1.1
+      uses: aws-actions/configure-aws-credentials@v6.0.0
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.aws_role }}

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
       shell: bash
       run: aws s3 sync out s3://${{ inputs.bucket_name }} --no-progress --follow-symlinks --delete --region ${{ inputs.cdk_deploy_region }}
     - name: Invalidate CloudFront cache
-      uses: chetan/invalidate-cloudfront-action@v2.4.1
+      uses: chetan/invalidate-cloudfront-action@v2.4.2
       env:
         AWS_REGION: ${{ inputs.cdk_deploy_region }}
         DISTRIBUTION: ${{ inputs.cloudfront_distribution_id }}


### PR DESCRIPTION
## Summary
- bump `chetan/invalidate-cloudfront-action` from `v2.4.1` to `v2.4.2`

## Validation
- `act --container-architecture linux/amd64 --container-daemon-socket - --container-options "--memory 4g" workflow_dispatch -W .github/workflows/build.yml -j build -s GITHUB_TOKEN="$TOKEN"`
- result: success
